### PR TITLE
Remove batch processing

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -20,4 +20,4 @@ names = WikiData::Category.new( 'Catégorie:Député de la XIVe législature de 
         WikiData::Category.new( 'Catégorie:Député de la XIIIe législature de la Ve République', 'fr').member_titles |
         WikiData::Category.new( 'Catégorie:Député de la XIIe législature de la Ve République', 'fr').member_titles
 
-EveryPolitician::Wikidata.scrape_wikidata(names: { fr: names }, batch_size: 50)
+EveryPolitician::Wikidata.scrape_wikidata(names: { fr: names })


### PR DESCRIPTION
Scraper was failing with timeouts possible caused by a failing batch fetch.

This commit removes batch processing. (Batch processing was introduced to save
memory but is not needed after recent wikisnakker update
(everypolitician/wikisnakker#50 ))

Removes batch_size argument from EveryPolitician::Wikidata.scrape_wikidata
